### PR TITLE
Fix for Apple web server security updates

### DIFF
--- a/ApplSec/main.py
+++ b/ApplSec/main.py
@@ -293,7 +293,7 @@ if entriesChanged > 0:
 if date.today().day == 1:
     lastMonth = int(date.today().strftime("%m")) - 1
     nameLastMonth = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][lastMonth - 1]
-    lastMonth = f"0{lastMonth}"
+    lastMonth = f"<em>0{lastMonth}"
 
     currentDateFormatThree = f"{date.today().year}-{lastMonth}"
 


### PR DESCRIPTION
Looks like Apple uses some other dates on the [Apple web server notifications](https://support.apple.com/en-us/HT201536) page, so they would be detected as a fix that Apple made in the previous month as the bot is searching for the same format. This PR should update the string so it will not match that anymore.

![image](https://user-images.githubusercontent.com/63184600/120312316-dbb92300-c2d8-11eb-8eae-c75978e51012.png)
